### PR TITLE
V0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+- 0.3.8
+  - Bugfix missing tensor dtype (#82)
+  - Support for 0 shim array shape_id
+  - Default shim in importer for pulses that do not specify any
+  - Deprecated old importer
 - 0.3.7
   - Support for loading .seq files with pTx rf_shim extension for pulseq
   - Support for loading .dsv files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "mrzero_core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "num-complex",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mrzero_core"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "requests>=2.20",
     "scikit-image",
     "torchkbnufft",
-    "pydisseqt>=0.1.12"
+    "pydisseqt>=0.1.13"
 ]
 
 [project.urls]

--- a/python/MRzeroCore/phantom/voxel_grid_phantom.py
+++ b/python/MRzeroCore/phantom/voxel_grid_phantom.py
@@ -393,7 +393,7 @@ class VoxelGridPhantom:
 
         def resample_multicoil(tensor: torch.Tensor) -> torch.Tensor:
             coils = tensor.shape[0]
-            output = torch.zeros(coils, x, y, z)
+            output = torch.zeros(coils, x, y, z, dtype=tensor.dtype)
             for i in range(coils):
                 re = resample(torch.real(tensor[i, ...]))
                 im = resample(torch.imag(tensor[i, ...]))

--- a/python/MRzeroCore/sequence.py
+++ b/python/MRzeroCore/sequence.py
@@ -419,6 +419,7 @@ class Sequence(list):
     def import_file(cls, file_name: str,
                     exact_trajectories: bool = True,
                     print_stats: bool = False,
+                    default_shim: torch.Tensor = torch.asarray([[1, 0]], dtype=torch.float32),
                     ref_voltage: float = 300.0,
                     resolution: Optional[int] = None,
                     ) -> Sequence:
@@ -436,6 +437,8 @@ class Sequence(list):
             the simulated diffusion changes with simplified trajectoreis.
         print_stats : bool
             If set to true, additional information is printed during import
+        default_shim : Tensor
+            The shim_array used for pulses that do not specify it themselves.
         ref_voltage : float
             If a .dsv file is imported, this is used to convert pulses from
             volts to angles. A 1 ms block pulse of ref_voltage is a 180 ° flip
@@ -551,7 +554,9 @@ class Sequence(list):
             rep.pulse.angle = pulse.angle
             rep.pulse.phase = pulse.phase
             rep.pulse.usage = pulse_usage(pulse.angle)
-            if shim is not None:
+            if shim is None:
+                rep.pulse.shim_array = default_shim.clone()
+            else:
                 rep.pulse.shim_array = torch.as_tensor(shim)
 
             rep.event_time[:] = torch.as_tensor(np.diff(abs_times))
@@ -591,7 +596,7 @@ class Sequence(list):
         Sequence
             Imported sequence, converted to MRzero
         """
-        print(
+        raise DeprecationWarning(
             "WARNING: Use of deprecated Sequence.from_seq_file,"
             "use Sequence.import_file instead"
         )


### PR DESCRIPTION
- Bugfix missing tensor dtype (#82)
- Support for 0 shim array shape_id
- Default shim in importer for pulses that do not specify any
- Deprecated old importer