### PR TITLE
Add ci for testing bssfp 2d seq

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -1,0 +1,29 @@
+name: Simulation Tests
+
+on: [push, pull_request]
+
+jobs:
+  simulation-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ipykernel  # ensures the python3 kernel is installed
+          python -m ipykernel install --user --name python3 --display-name "Python 3"
+          pip install -r tests/requirements.txt
+
+      - name: Install PyTorch CPU-only
+        run: pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Run tests
+        run: |
+          pytest -p no:warnings --disable-warnings tests/

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,10 @@
+nbformat
+numpy
+pytest
+pypulseq
+torchkbnufft
+MRzeroCore
+pydisseqt
+requests>=2.20
+scikit-image
+matplotlib

--- a/tests/test_bssfp.py
+++ b/tests/test_bssfp.py
@@ -1,0 +1,78 @@
+from tests.utils import exec_notebook, load_reference
+import numpy as np
+import pathlib
+from typing import Dict, Any,Tuple
+
+def compare_bssfp_outputs(actual: Dict[str, Any], reference: Dict[str, Any], thresholds: Dict[str, float]) -> Tuple[bool, str]:
+    """
+    Compare bSSFP simulation outputs from a notebook against reference data.
+
+    Parameters:
+        actual (Dict[str, Any]): Dictionary of variables from the executed notebook.
+        reference (Dict[str, Any]): Dictionary of reference data (from .npz file).
+        thresholds (Dict[str, float]): Thresholds for normalized magnitude rmse, phase rmse, and runtime deviation percentage.
+            Expected keys: "mag_nrmse", "phase_nrmse", "dt_percent".
+
+    Returns:
+        Tuple[bool, str]: (passed, message), where `passed` indicates whether the comparison was successful,
+                          and `message` provides diagnostic information.
+    """
+    acc_array = actual.get("acc_array")
+    dt = actual.get("dt")
+    space_3d = actual.get("space_3d")
+
+    ref_acc_array = reference.get("acc_array")
+    ref_dt = reference.get("dt")
+    ref_space_3d = reference.get("space_3d")
+
+
+    if(acc_array is None) : return False, "Missing required variable acc_array in notebook output."
+    if(dt is None) : return False, "Missing required variable dt in notebook output."
+    if(space_3d is None) : return False, "Missing required variable space_3d in notebook output."
+
+    # Check lengths match
+    if len(acc_array) != len(ref_acc_array):
+        return False, "acc_array length mismatch."
+
+    for i in range(len(acc_array)):
+        acc = acc_array[i]
+        mag_rmse = np.sqrt(np.mean((np.abs(space_3d[i]) - np.abs(ref_space_3d[i])) ** 2)) / np.mean(np.abs(space_3d[i]))
+        phase_rmse = np.sqrt(np.mean((np.angle(space_3d[i]) - np.angle(ref_space_3d[i])) ** 2))
+        dt_diff_percent = abs((dt[i] - ref_dt[i]) / ref_dt[i]) * 100
+
+        if mag_rmse > thresholds["mag_nrmse"]:
+            return False, f"Mag RMSE too high ({mag_rmse:.5f}) at acc={acc:.5f}"
+        
+        if phase_rmse > thresholds["phase_nrmse"]:
+            return False, f"Phase RMSE too high ({phase_rmse:.5f}) at acc={acc:.5f}"
+        
+        if dt_diff_percent > thresholds["dt_percent"]:
+            return False, f"Runtime deviation too high ({dt_diff_percent:.2f}%) at acc={acc:.5f}"
+
+    return True, "All tests passed."
+
+def test_bssfp_simulation() -> None:
+    """
+    Run an automated test for bSSFP simulation by executing a notebook and comparing its output 
+    to a reference dataset using defined accuracy and timing thresholds.
+    
+    Raises:
+        AssertionError: If the notebook or reference file is not found,
+                        or if the output comparison fails the defined thresholds.
+    """
+    notebook_path = "documentation/playground_mr0/mr0_bSSFP_2D_seq.ipynb"
+    assert pathlib.Path(notebook_path).is_file(), f"Notebook file not found: {notebook_path}" 
+
+    reference_path = "documentation/playground_mr0/reference_bssfp_data_feb2025.npz"
+    assert pathlib.Path(reference_path).is_file(), f"Reference data file not found: {reference_path}" 
+
+    thresholds = {
+        "mag_nrmse": 0.01,
+        "phase_nrmse": 0.01,
+        "dt_percent": 80.0,
+    }
+
+    actual = exec_notebook(notebook_path)
+    reference = load_reference(reference_path)
+    passed, message = compare_bssfp_outputs(actual, reference, thresholds)
+    assert passed, message

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,70 @@
+import numpy as np
+import glob
+import os
+import shutil
+from nbformat import read
+import matplotlib
+from typing import Dict, Any
+
+def exec_notebook(nb_path : str) -> Dict[str, Any]: 
+    """
+    Load and execute a Jupyter notebook, returning a dictionary representing 
+    the namespace (variables and functions) defined within the notebook.
+
+    Parameters:
+        nb_path (str): Path to the Jupyter notebook file (.ipynb).
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the variables defined during notebook execution.
+    """
+
+    matplotlib.use('Agg') # Silence matplotlib outputs
+
+    # Load notebook
+    with open(nb_path) as f:
+        nb = read(f, as_version=4)
+
+    namespace = {}
+    for cell in nb.cells:
+        if cell.cell_type == "code":
+            try:
+                exec(cell.source, namespace, namespace)
+            except Exception as e:
+                print("Error executing cell:", e)
+
+    cleanup_generated_files()
+    return namespace
+
+def cleanup_generated_files() -> None:
+    """
+    Remove temporary or generated files matching specific patterns 
+    (e.g., images, data files, checkpoints) from the current directory.
+    """
+
+    patterns = [
+        "*.png", "*.jpg", "*.jpeg", "*.svg", "*.gif",
+        "*.json", "*.npz", "*.npy", "*.mat",
+        ".ipynb_checkpoints",".seq"
+    ]
+    for pattern in patterns:
+        for path in glob.glob(pattern):
+            if os.path.isdir(path):
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    os.remove(path)
+                except FileNotFoundError:
+                    pass
+
+def load_reference(npz_path: str) -> Dict[str, np.ndarray]:
+    """
+    Load a numpy .npz file and return its contents as a dictionary.
+
+    Parameters:
+        npz_path (str): Path to the .npz reference file.
+
+    Returns:
+        Dict[str, np.ndarray]: Dictionary mapping variable names to arrays stored in the .npz file.
+    """
+    with np.load(npz_path) as data:
+        return dict(data)


### PR DESCRIPTION
- I added a new tests folder, which currently includes only the test for the bSSFP sequence.

- I also added a CI test pipeline for validating the bSSFP simulation. The test relies on executing the existing notebook directly. This approach was chosen because you already have multiple notebooks, and integrating them into the pipeline this way will make it easier to expand in the future if more notebooks are added.

- **Note on timing deviation:** Measuring runtime deviation is challenging in the CI environment, since the simulation runs on shared runners, which are typically slower than environments like Google Colab. As a result, slower execution doesn’t necessarily mean there's a problem with the simulation itself. I initially set the runtime deviation threshold to 80% to account for potential performance differences. If the CI environment is more than 80% slower than the reference, that may indicate a performance issue worth investigating.