### PR TITLE
Playground corrections

### DIFF
--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -33,15 +33,14 @@ chapters:
   - file: playground_mr0/mr0_STE_3pulses_5echoes_seq.ipynb
   - file: playground_mr0/mr0_FLASH_2D_seq.ipynb
   - file: playground_mr0/mr0_EPI_2D_seq.ipynb
-  - file: playground_mr0/mr0_RARE_2D_seq.ipynb
-  - file: playground_mr0/mr0_bSSFP_2D_seq.ipynb
+  - file: playground_mr0/mr0_DWI_SE_EPI.ipynb
   - file: playground_mr0/mr0_diffusion_prep_STEAM_2D_seq.ipynb
+  - file: playground_mr0/mr0_RARE_2D_seq.ipynb
+  - file: playground_mr0/mr0_TSE_2D_multi_shot_seq.ipynb
   - file: playground_mr0/mr0_GRE_to_FLASH.ipynb
+  - file: playground_mr0/mr0_bSSFP_2D_seq.ipynb
   - file: playground_mr0/mr0_DREAM_STE_seq.ipynb
   - file: playground_mr0/mr0_DREAM_STID_seq.ipynb
-  - file: playground_mr0/mr0_burst_TSE.ipynb
-  - file: playground_mr0/mr0_CS_cartesian_seq.ipynb
-  - file: playground_mr0/mr0_CS_radial_seq.ipynb
   - file: playground_mr0/pulseq_rf_shim.ipynb
 
   - file: playground_mr0/mr0_pypulseq_exmpls_seq.ipynb
@@ -49,11 +48,12 @@ chapters:
 
   - file: playground_mr0/mr0_opt_FLASH_2D_IR_Fit_T1.ipynb
   - file: playground_mr0/mr0_opt_FLASH_2D_IR_voxelNN_T1.ipynb
+  - file: playground_mr0/Pulseq_zero_FLASH_FAopt_PSFtask.ipynb
+  - file: playground_mr0/Pulseq_zero_TSE_FAopt_SARtask.ipynb
+  - file: playground_mr0/pulseq_zero_DESC_demo.ipynb
 
   - file: playground_mr0/mr00_FLASH_2D_ernstAngle_opt.ipynb
 
   - file: playground_mr0/flash
-  - file: playground_mr0/flash_DWI
   - file: playground_mr0/pulseq_flash
   - file: playground_mr0/pulseq_sim_pTx
-  - file: playground_mr0/pulseq_zero_DESC_demo

--- a/documentation/playground_mr0/Pulseq_zero_FLASH_FAopt_PSFtask.ipynb
+++ b/documentation/playground_mr0/Pulseq_zero_FLASH_FAopt_PSFtask.ipynb
@@ -9,8 +9,8 @@
       "outputs": [],
       "source": [
         "!pip install pulseqzero &> /dev/null\n",
-        "!pip install MRzeroCore &> /dev/null\n",
         "!pip install ismrmrd\n",
+        "!pip install MRzeroCore &> /dev/null\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
       ]
@@ -39,7 +39,7 @@
       },
       "source": [
         "(FLASH_FAopt_PSF)=\n",
-        "# Pulseq-zero Demo\n",
+        "# FLASH flip angle opt. for PSF (with pulseq-zero)\n",
         "Pulseq-zero combines Pusleq and MR-zero and allows you to optimize a Pulseq sequence dirrectly.\n",
         "\n",
         "For example, herein we want to optimize the variable flip angles of a single shot FLASH sequence to improve the PSF to achieve the sharpness of a multi-shot FLASH\n",

--- a/documentation/playground_mr0/Pulseq_zero_TSE_FAopt_SARtask.ipynb
+++ b/documentation/playground_mr0/Pulseq_zero_TSE_FAopt_SARtask.ipynb
@@ -77,11 +77,29 @@
       "source": [
         "!pip install pypulseq==1.4.2\n",
         "!pip install pulseqzero\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps &> /dev/null\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mo3OlL518O4O"
+      },
+      "source": [
+        "(TSE_FAopt_SAR)=\n",
+        "# TSE flip angle opt. for SAR (with pulseq-zero)\n",
+        "Pulseq-zero combines Pusleq and MR-zero and allows you to optimize a Pulseq sequence dirrectly.\n",
+        "\n",
+        "For example, herein we want to optimize the variable refocusing flip angle train of a TSE sequence to achieve low SAR.\n",
+        "\n",
+        "\n",
+        "\n",
+        "###First,###\n",
+        "we now need to define a TSE sequence as function with parameters we wish to optimize as arguments:"
       ]
     },
     {
@@ -114,24 +132,6 @@
         "import MRzeroCore as mr0\n",
         "import pulseqzero\n",
         "pp = pulseqzero.pp_impl"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mo3OlL518O4O"
-      },
-      "source": [
-        "(TSE_FAopt_SAR)=\n",
-        "# Pulseq-zero Demo\n",
-        "Pulseq-zero combines Pusleq and MR-zero and allows you to optimize a Pulseq sequence dirrectly.\n",
-        "\n",
-        "For example, herein we want to optimize the variable refocusing flip angle train of a TSE sequence to achieve low SAR.\n",
-        "\n",
-        "\n",
-        "\n",
-        "###First,###\n",
-        "we now need to define a TSE sequence as function with parameters we wish to optimize as arguments:"
       ]
     },
     {

--- a/documentation/playground_mr0/flash.ipynb
+++ b/documentation/playground_mr0/flash.ipynb
@@ -18,8 +18,8 @@
     }
    ],
    "source": [
-    "!pip install MRzeroCore &> /dev/null\n",
-    "!pip install ismrmrd"
+    "!pip install ismrmrd\n",
+    "!pip install MRzeroCore &> /dev/null"
    ]
   },
   {
@@ -40,7 +40,7 @@
    "metadata": {},
    "source": [
     "(flash)=\n",
-    "# Create a FLASH Sequence\n",
+    "# Pure `MR0` FLASH\n",
     "\n",
     "This Notebook demonstrates a simple Fast Low Angle SHot sequence (FLASH). It is a simple gradient echo sequence with low TR and flip angles typically below 10°.\n",
     "\n",

--- a/documentation/playground_mr0/mr00_FLASH_2D_ernstAngle_opt.ipynb
+++ b/documentation/playground_mr0/mr00_FLASH_2D_ernstAngle_opt.ipynb
@@ -28,8 +28,8 @@
    "source": [
     "!pip install pypulseq==1.3.1.post1 &> /dev/null\n",
     "!pip install nevergrad &> /dev/null\n",
-    "!pip install MRzeroCore &> /dev/null\n",
     "!pip install ismrmrd\n",
+    "!pip install MRzeroCore &> /dev/null\n",
     "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
    ]
   },
@@ -68,7 +68,7 @@
    "metadata": {},
    "source": [
     "(mr00_FLASH_2D_ernstAngle_opt)=\n",
-    "# MR00 2D FLASH Ernst angle optimization"
+    "# Ernst angle optimization"
    ]
   },
   {

--- a/documentation/playground_mr0/mr0_DREAM_STE_seq.ipynb
+++ b/documentation/playground_mr0/mr0_DREAM_STE_seq.ipynb
@@ -51,11 +51,27 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-c7sfLe55zkV"
+      },
+      "source": [
+        "(DREAM_STE_seq)=\n",
+        "# DREAM STE for B0, B1, TxRx mapping\n",
+        "\n",
+        "This is a pulseq implementation of the single slice DREAM sequence [1] using the STE first timing scheme and thus enabling the mapping of B1, B0 and transceive chain phase.\n",
+        "\n",
+        "---\n",
+        "\n",
+        "[1] Nehrke, K. and Börnert, P. (2012), DREAM—a novel approach for robust, ultrafast, multislice B1 mapping. Magn Reson Med, 68: 1517-1526. https://doi.org/10.1002/mrm.24158"
       ]
     },
     {
@@ -81,22 +97,6 @@
         "\n",
         "## import for fitting\n",
         "from scipy.stats import linregress"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-c7sfLe55zkV"
-      },
-      "source": [
-        "(DREAM_STE_seq)=\n",
-        "# STE - DREAM\n",
-        "\n",
-        "This is a pulseq implementation of the single slice DREAM sequence [1] using the STE first timing scheme and thus enabling the mapping of B1, B0 and transceive chain phase.\n",
-        "\n",
-        "---\n",
-        "\n",
-        "[1] Nehrke, K. and Börnert, P. (2012), DREAM—a novel approach for robust, ultrafast, multislice B1 mapping. Magn Reson Med, 68: 1517-1526. https://doi.org/10.1002/mrm.24158"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_DREAM_STID_seq.ipynb
+++ b/documentation/playground_mr0/mr0_DREAM_STID_seq.ipynb
@@ -51,11 +51,29 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CAOrQ9TmD0U9"
+      },
+      "source": [
+        "(DREAM_STID_seq)=\n",
+        "# DREAM STID for B0, B1, TxRx mapping\n",
+        "\n",
+        "This is a pulseq implementation of the single slice DREAM sequence [1] using the STID first (STE* first) timing scheme and thus enabling the mapping of B1.\n",
+        "\n",
+        "Also a B0 map is reconstructed here, but due to the timing, it is zero as expected.\n",
+        "\n",
+        "---\n",
+        "\n",
+        "[1] Nehrke, K., Versluis, M.J., Webb, A. and Börnert, P. (2014), Volumetric B1+ Mapping of the Brain at 7T using DREAM. Magn. Reson. Med., 71: 246-256. https://doi.org/10.1002/mrm.24667"
       ]
     },
     {
@@ -83,24 +101,6 @@
         "\n",
         "## import for fitting\n",
         "from scipy.stats import linregress"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "CAOrQ9TmD0U9"
-      },
-      "source": [
-        "(DREAM_STID_seq)=\n",
-        "# STID - DREAM\n",
-        "\n",
-        "This is a pulseq implementation of the single slice DREAM sequence [1] using the STID first (STE* first) timing scheme and thus enabling the mapping of B1.\n",
-        "\n",
-        "Also a B0 map is reconstructed here, but due to the timing, it is zero as expected.\n",
-        "\n",
-        "---\n",
-        "\n",
-        "[1] Nehrke, K., Versluis, M.J., Webb, A. and Börnert, P. (2014), Volumetric B1+ Mapping of the Brain at 7T using DREAM. Magn. Reson. Med., 71: 246-256. https://doi.org/10.1002/mrm.24667"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_DWI_SE_EPI.ipynb
+++ b/documentation/playground_mr0/mr0_DWI_SE_EPI.ipynb
@@ -48,9 +48,9 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/subject05.npz &> /dev/null"
       ]
@@ -62,7 +62,7 @@
       },
       "source": [
         "(DWI_SE_EPI_seq)=\n",
-        "# 2D DWI SE EPI"
+        "# DWI SE EPI 2D sequence"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_EPI_2D_seq.ipynb
+++ b/documentation/playground_mr0/mr0_EPI_2D_seq.ipynb
@@ -37,11 +37,21 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4lGMmQkG8-tB"
+      },
+      "source": [
+        "(EPI_2D_seq)=\n",
+        "# GRE EPI 2D sequence"
       ]
     },
     {
@@ -58,16 +68,6 @@
         "\n",
         "plt.rcParams['figure.figsize'] = [10, 5]\n",
         "plt.rcParams['figure.dpi'] = 100\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4lGMmQkG8-tB"
-      },
-      "source": [
-        "(EPI_2D_seq)=\n",
-        "# 2D EPI"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_FID_seq.ipynb
+++ b/documentation/playground_mr0/mr0_FID_seq.ipynb
@@ -23,9 +23,9 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
       ]
@@ -37,7 +37,7 @@
       },
       "source": [
         "(FID_seq)=\n",
-        "# Free induction decay"
+        "# Free Induction Decay"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_FLASH_2D_seq.ipynb
+++ b/documentation/playground_mr0/mr0_FLASH_2D_seq.ipynb
@@ -51,11 +51,21 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "26qETVec6mx3"
+      },
+      "source": [
+        "(FLASH_2D_seq)=\n",
+        "# FLASH 2D sequence"
       ]
     },
     {
@@ -72,16 +82,6 @@
         "\n",
         "plt.rcParams['figure.figsize'] = [10, 5]\n",
         "plt.rcParams['figure.dpi'] = 100 # 200 e.g. is really fine, but slower"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "26qETVec6mx3"
-      },
-      "source": [
-        "(FLASH_2D_seq)=\n",
-        "# 2D FLASH"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_GRE_to_FLASH.ipynb
+++ b/documentation/playground_mr0/mr0_GRE_to_FLASH.ipynb
@@ -27,9 +27,9 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
-        "!pip install pydisseqt\n",
-        "!pip install ismrmrd"
+        "!pip install pydisseqt"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_RARE_2D_seq.ipynb
+++ b/documentation/playground_mr0/mr0_RARE_2D_seq.ipynb
@@ -23,11 +23,21 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Vp6yK0GH3BXF"
+      },
+      "source": [
+        "(RARE_2D_seq)=\n",
+        "# RARE 2D sequence"
       ]
     },
     {
@@ -44,16 +54,6 @@
         "\n",
         "plt.rcParams['figure.figsize'] = [10, 5]\n",
         "plt.rcParams['figure.dpi'] = 100"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Vp6yK0GH3BXF"
-      },
-      "source": [
-        "(RARE_2D_seq)=\n",
-        "# 2D RARE"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_SE_CPMG_seq.ipynb
+++ b/documentation/playground_mr0/mr0_SE_CPMG_seq.ipynb
@@ -23,9 +23,9 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
       ]
@@ -37,7 +37,7 @@
       },
       "source": [
         "(SE_CPMG_seq)=\n",
-        "# Spin Echo - CPMG"
+        "# Spin Echo CPMG"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_STE_3pulses_5echoes_seq.ipynb
+++ b/documentation/playground_mr0/mr0_STE_3pulses_5echoes_seq.ipynb
@@ -23,11 +23,21 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sm9mcxuRD_bF"
+      },
+      "source": [
+        "(STE_3pulses_5echoes_seq)=\n",
+        "# Stimulated Echo 3 pulses - 5 echoes"
       ]
     },
     {
@@ -46,16 +56,6 @@
         "\n",
         "plt.rcParams['figure.figsize'] = [10, 5]\n",
         "plt.rcParams['figure.dpi'] = 100 # 200 e.g. is really fine, but slower"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sm9mcxuRD_bF"
-      },
-      "source": [
-        "(STE_3pulses_5echoes_seq)=\n",
-        "# STE in a brain phantom"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_TSE_2D_multi_shot_seq.ipynb
+++ b/documentation/playground_mr0/mr0_TSE_2D_multi_shot_seq.ipynb
@@ -27,11 +27,21 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Vp6yK0GH3BXF"
+      },
+      "source": [
+        "(TSE_2D_seq)=\n",
+        "# TSE 2D sequence"
       ]
     },
     {
@@ -48,16 +58,6 @@
         "\n",
         "plt.rcParams['figure.figsize'] = [10, 5]\n",
         "plt.rcParams['figure.dpi'] = 100 # 200 e.g. is really fine, but slower"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Vp6yK0GH3BXF"
-      },
-      "source": [
-        "(TSE_2D_seq)=\n",
-        "# 2D TSE"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_bSSFP_2D_seq.ipynb
+++ b/documentation/playground_mr0/mr0_bSSFP_2D_seq.ipynb
@@ -51,9 +51,9 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground/quantified_brain.npz &> /dev/null"
@@ -67,7 +67,7 @@
       "source": [
         "(bSSFP_seq)=\n",
         "\n",
-        "# Imports and definitions"
+        "# balanced SSFP sequence"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_diffusion_prep_STEAM_2D_seq.ipynb
+++ b/documentation/playground_mr0/mr0_diffusion_prep_STEAM_2D_seq.ipynb
@@ -33,22 +33,9 @@
       "source": [
         "!pip install pypulseq &> /dev/null\n",
         "!pip install  torchkbnufft --no-deps\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps\n",
-        "!pip install pydisseqt\n",
-        "!pip install ismrmrd"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import torch\n",
-        "import matplotlib.pyplot as plt\n",
-        "import pypulseq as pp\n",
-        "import MRzeroCore as mr0"
+        "!pip install pydisseqt"
       ]
     },
     {
@@ -57,7 +44,7 @@
       "source": [
         "(diff_prep_STEAM_seq)=\n",
         "\n",
-        "# Diffusion prepared STEAM sequence\n",
+        "# Diffusion prepared STEAM\n",
         "\n",
         "This notebook demonstrates a diffusion-prepared STEAM (Stimulated Echo Acquisition Mode) sequence with T₂ preparation module consisting of 90°, 180°, -90° pulses and diffusion gradients.\n",
         "\n",
@@ -79,6 +66,19 @@
         "|  gray matter |                   0.83 |\n",
         "| white matter |                   0.65 |\n",
         "|          CSF |                   3.19 |"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import torch\n",
+        "import matplotlib.pyplot as plt\n",
+        "import pypulseq as pp\n",
+        "import MRzeroCore as mr0"
       ]
     },
     {

--- a/documentation/playground_mr0/mr0_opt_FLASH_2D_IR_Fit_T1.ipynb
+++ b/documentation/playground_mr0/mr0_opt_FLASH_2D_IR_Fit_T1.ipynb
@@ -23,10 +23,10 @@
    "outputs": [],
    "source": [
     "!pip install pypulseq==1.3.1.post1 &> /dev/null\n",
+    "!pip install ismrmrd\n",
     "!pip install MRzeroCore &> /dev/null\n",
     "!pip install pytorch-minimize &> /dev/null\n",
     "!pip install jupyterplot &> /dev/null\n",
-    "!pip install ismrmrd\n",
     "\n",
     "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
    ]
@@ -46,7 +46,7 @@
    "metadata": {},
    "source": [
     "(IR_FLASH_fit)=\n",
-    "# Optimized IR FLASH for T1 fit"
+    "# IR FLASH 2D sequence for T1 mapping using a fit"
    ]
   },
   {

--- a/documentation/playground_mr0/mr0_opt_FLASH_2D_IR_voxelNN_T1.ipynb
+++ b/documentation/playground_mr0/mr0_opt_FLASH_2D_IR_voxelNN_T1.ipynb
@@ -22,11 +22,11 @@
    },
    "outputs": [],
    "source": [
+    "!pip install ismrmrd\n",
     "!pip install MRzeroCore &> /dev/null\n",
     "!pip install pypulseq==1.3.1.post1 &> /dev/null\n",
     "!pip install pytorch-minimize &> /dev/null\n",
     "!pip install jupyterplot &> /dev/null\n",
-    "!pip install ismrmrd\n",
     "\n",
     "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
    ]
@@ -46,7 +46,7 @@
    "metadata": {},
    "source": [
     "(IR_FLASH_NN)=\n",
-    "# Pixel-wise NN T1 Mapping"
+    "# IR FLASH 2D sequence for T1 mapping using a NN"
    ]
   },
   {

--- a/documentation/playground_mr0/mr0_pypulseq_exmpls_seq.ipynb
+++ b/documentation/playground_mr0/mr0_pypulseq_exmpls_seq.ipynb
@@ -22,8 +22,8 @@
    "outputs": [],
    "source": [
     "!pip install pypulseq==1.3.1.post1 &> /dev/null\n",
-    "!pip install MRzeroCore &> /dev/null\n",
     "!pip install ismrmrd\n",
+    "!pip install MRzeroCore &> /dev/null\n",
     "\n",
     "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
    ]
@@ -45,7 +45,7 @@
    },
    "source": [
     "(mr0_pypulseq_example)=\n",
-    "# Simulate pypulseq example files\n",
+    "# Simulate pypulseq example sequences\n",
     "here the pypulseq example files from pypulseq/seq_examples.scripts"
    ]
   },

--- a/documentation/playground_mr0/mr0_upload_seq.ipynb
+++ b/documentation/playground_mr0/mr0_upload_seq.ipynb
@@ -17,9 +17,9 @@
         "# for 1.4 files, use one of:\n",
         "!pip install pypulseq &> /dev/null\n",
         "\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps &> /dev/null\n",
         "!pip install pydisseqt\n",
-        "!pip install ismrmrd\n",
         "\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/numerical_brain_cropped.mat &> /dev/null"
       ]
@@ -31,7 +31,7 @@
       },
       "source": [
         "(mr0_upload_seq)=\n",
-        "# Upload own seq files\n",
+        "# Simulate own uploaded seq files\n",
         "Here  you can upload and simulate own seq files.\n",
         "Some tested seq-files can be found [here](https://drive.google.com/drive/folders/1EfQRpSXypv3O-t8qn0C6m16xlya_B2Pg). You can download them and then reupload one of these, or an own own seq-file and then simulate them in a brain phantom.\n"
       ]

--- a/documentation/playground_mr0/pulseq_flash.ipynb
+++ b/documentation/playground_mr0/pulseq_flash.ipynb
@@ -11,8 +11,8 @@
    "outputs": [],
    "source": [
     "!pip install pypulseq==1.3.1.post1 &> /dev/null\n",
-    "!pip install MRzeroCore &> /dev/null\n",
     "!pip install ismrmrd\n",
+    "!pip install MRzeroCore &> /dev/null\n",
     "\n",
     "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/subject05.npz &> /dev/null"
    ]
@@ -53,7 +53,7 @@
    "metadata": {},
    "source": [
     "(pulseq_flash)=\n",
-    "# Pulseq and MRzeroCore\n",
+    "# pulseq FLASH\n",
     "\n",
     "MRzero Core has functionality to parse and simulate pulseq .seq files.\n",
     "We build the same pulseq sequence as before, but this time with pulseq."

--- a/documentation/playground_mr0/pulseq_rf_shim.ipynb
+++ b/documentation/playground_mr0/pulseq_rf_shim.ipynb
@@ -18,8 +18,8 @@
         "#@title 0. Install mr0\n",
         "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/ptx_phantom.p &> /dev/null\n",
         "!pip install git+https://gitlab.cs.fau.de/mrzero/pypulseq_rfshim.git@PyPulseq_rfshim_145_MR0 &> /dev/null\n",
-        "!pip install MRzeroCore &> /dev/null\n",
-        "!pip install ismrmrd"
+        "!pip install ismrmrd\n",
+        "!pip install MRzeroCore &> /dev/null"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "metadata": {},
       "source": [
         "(pulseq_ptx)=\n",
-        "# Pulseq with RF Shimming"
+        "# Pulseq with RF shimming"
       ]
     },
     {

--- a/documentation/playground_mr0/pulseq_sim_pTx.ipynb
+++ b/documentation/playground_mr0/pulseq_sim_pTx.ipynb
@@ -24,8 +24,8 @@
    "outputs": [],
    "source": [
     "!pip install pypulseq==1.3.1.post1 &> /dev/null\n",
-    "!pip install MRzeroCore &> /dev/null\n",
     "!pip install ismrmrd\n",
+    "!pip install MRzeroCore &> /dev/null\n",
     "\n",
     "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/subject05.npz &> /dev/null\n",
     "!wget https://github.com/MRsources/MRzero-Core/raw/main/documentation/playground_mr0/AdjDataUser2gB0_transversal_0.08moving_average.mat &> /dev/null"
@@ -62,7 +62,7 @@
    "source": [
     "(pulseq_pTx_sim)=\n",
     "\n",
-    "# Simulating a pTx .seq with MR0"
+    "# pulseq pTx FLASH"
    ]
   },
   {

--- a/documentation/playground_mr0/pulseq_zero_DESC_demo.ipynb
+++ b/documentation/playground_mr0/pulseq_zero_DESC_demo.ipynb
@@ -4,9 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MRsources/MRzero-Core/blob/main/documentation/playground_mr0/pulseq_zero_DESC_demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
-        "\n",
-        "(pulseq_DESC)="
+        "<a href=\"https://colab.research.google.com/github/MRsources/MRzero-Core/blob/main/documentation/playground_mr0/pulseq_zero_DESC_demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -25,9 +23,17 @@
         "\n",
         "!pip install git+https://gitlab.cs.fau.de/mrzero/pypulseq_rfshim &> /dev/null\n",
         "!pip install pulseqzero\n",
+        "!pip install ismrmrd\n",
         "!pip install MRzeroCore --no-deps &> /dev/null\n",
-        "!pip install pydisseqt\n",
-        "!pip install ismrmrd"
+        "!pip install pydisseqt"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "(pulseq_DESC)=\n",
+        "# DESC with pulseq-zero](pulseq_DESC)"
       ]
     },
     {


### PR DESCRIPTION
- Changed sequences on _toc.md so that sections on the sidebar of playground match tha table on overview.md;
- Changed the title of the notebooks to also do this matching;
- Changed the order of the installation of ismrmrd and MRzeroCore so that the error associated with ismrmrd during the mr0 installation does not appear;
- Changed the order of the notebook title and import section just for uniformity across the notebookd;