### PR TITLE
Display main pass progression using tqdm instead of prints

### DIFF
--- a/python/MRzeroCore/simulation/main_pass.py
+++ b/python/MRzeroCore/simulation/main_pass.py
@@ -5,6 +5,7 @@ from ..sequence import Sequence
 from ..phantom.sim_data import SimData
 from .pre_pass import Graph
 import numpy as np
+from tqdm.auto import tqdm
 
 
 # NOTE: return encoding and magnetization is currently missing. If we want to
@@ -103,9 +104,10 @@ def execute_graph(graph: Graph,
     graph[0][0].kt_vec = torch.zeros(4, device=data.device)
 
     mag_adc = []
-    for i, (dists, rep) in enumerate(zip(graph[1:], seq)):
+    pbar = tqdm(total=len(seq), desc="Calculating repetitions", disable=not print_progress)
+    for dists, rep in zip(graph[1:], seq):
         if print_progress:
-            print(f"\rCalculating repetition {i+1} / {len(seq)}", end='')
+            pbar.update(1)
 
         angle = torch.as_tensor(rep.pulse.angle)
         phase = torch.as_tensor(rep.pulse.phase)
@@ -278,7 +280,8 @@ def execute_graph(graph: Graph,
                     ancestor[1].mag = None
 
     if print_progress:
-        print(" - done")
+        pbar.close()
+        print('Done.')
 
     if return_mag_adc:
         return torch.cat(signal), mag_adc


### PR DESCRIPTION
Greetings. Thought I'd add monitoring of the main pass using tqdm, as when doing longer runs, it becomes quite hard to estimate time remaining from process wall time + repetition count. I run simulations spanning multiple hours, and this would be highly useful. Changes are quite small, only a few lines.
Not adding in the tqdm dependency, already included in the project.