### PR TITLE
Add affine matrix to phantom mz

### DIFF
--- a/python/MRzeroCore/phantom/tissue_dict.py
+++ b/python/MRzeroCore/phantom/tissue_dict.py
@@ -154,19 +154,37 @@ class TissueDict(dict[str, VoxelGridPhantom]):
         phantoms = list(self.values())
 
         PD = sum(p.PD for p in phantoms)
-        segmentation = [p.PD / PD for p in phantoms]
-        
+        # Segmented phantoms have background voxels where every tissue has
+        # PD == 0. A plain ``p.PD / PD`` divides 0 / 0 -> NaN there; guard the
+        # denominator so empty voxels get a weight of 0 instead.
+        denom = torch.where(PD > 0, PD, torch.ones_like(PD))
+        segmentation = [p.PD / denom for p in phantoms]
+
+        def weighted_sum(values: list[torch.Tensor]) -> torch.Tensor:
+            # ``torch.where`` keeps zero-weight voxels at 0 even when the tissue
+            # carries a default (infinite) relaxation value, avoiding the
+            # 0 * inf == NaN that would otherwise reach ``compute_graph``.
+            total = None
+            for seg, value in zip(segmentation, values):
+                weight = seg
+                while weight.ndim < value.ndim:
+                    weight = weight[None, ...]
+                term = torch.where(weight > 0, weight * value,
+                                   torch.zeros_like(value))
+                total = term if total is None else total + term
+            return total
+
         from copy import deepcopy
         combined = deepcopy(phantoms[0])
         combined.PD = PD
-        combined.T1 = sum(seg * p.T1 for seg, p in zip(segmentation, phantoms))
-        combined.T2 = sum(seg * p.T2 for seg, p in zip(segmentation, phantoms))
-        combined.T2dash = sum(seg * p.T2dash for seg, p in zip(segmentation, phantoms))
-        combined.D = sum(seg * p.D for seg, p in zip(segmentation, phantoms))
-        combined.B0 = sum(seg * p.B0 for seg, p in zip(segmentation, phantoms))
-        combined.B1 = sum(seg[None, ...] * p.B1 for seg, p in zip(segmentation, phantoms))
-        combined.coil_sens = sum(seg[None, ...] * p.coil_sens for seg, p in zip(segmentation, phantoms))
-        
+        combined.T1 = weighted_sum([p.T1 for p in phantoms])
+        combined.T2 = weighted_sum([p.T2 for p in phantoms])
+        combined.T2dash = weighted_sum([p.T2dash for p in phantoms])
+        combined.D = weighted_sum([p.D for p in phantoms])
+        combined.B0 = weighted_sum([p.B0 for p in phantoms])
+        combined.B1 = weighted_sum([p.B1 for p in phantoms])
+        combined.coil_sens = weighted_sum([p.coil_sens for p in phantoms])
+
         return combined
 
     def build(self, PD_threshold: float = 1e-6,
@@ -398,6 +416,13 @@ def _resample_nifti(data: np.ndarray, nifti_affine: np.ndarray,
         Maps target voxel ``[i, j, k]`` to physical coordinates in mm.
     """
     from scipy.ndimage import affine_transform
+
+    # A constant field stays constant under any resampling. Short-circuit this
+    # case so that constant defaults (e.g. T2 == inf for "no decay") survive:
+    # feeding non-finite values to ``affine_transform`` would yield NaNs.
+    flat = np.asarray(data).reshape(-1)
+    if flat.size > 0 and np.all(flat == flat[0]):
+        return np.full(tuple(target_shape), flat[0], dtype=float)
 
     A = np.array(target_affine_mm, dtype=float)
     A_rot   = A[:3, :3]

--- a/python/MRzeroCore/phantom/voxel_grid_phantom.py
+++ b/python/MRzeroCore/phantom/voxel_grid_phantom.py
@@ -38,6 +38,23 @@ def identity(trajectory: torch.Tensor) -> torch.Tensor:
     return torch.ones_like(trajectory[:, 0])
 
 
+def rescale_affine(affine: torch.Tensor,
+                   old_shape, new_shape) -> torch.Tensor:
+    """Rescale a voxel-to-world affine for a changed grid resolution.
+
+    Resampling (e.g. :meth:`VoxelGridPhantom.interpolate`) keeps the same
+    field of view but changes the number of voxels. The affine encodes the
+    per-voxel step (its 3x3 part) and the world origin (its last column). Only
+    the per-voxel step must change: scaling column ``i`` by
+    ``old_shape[i] / new_shape[i]`` keeps the total extent (and the origin)
+    constant while preserving any rotation/shear in the affine.
+    """
+    scaled = affine.clone()
+    for i in range(3):
+        scaled[:3, i] = affine[:3, i] * (old_shape[i] / new_shape[i])
+    return scaled
+
+
 def generate_B0_B1(PD):
     # Generate a somewhat plausible B0 and B1 map.
     # Visually fitted to look similar to the numerical_brain_cropped
@@ -340,6 +357,17 @@ class VoxelGridPhantom:
                 coils, *list(self.PD.shape[:2]), len(slices)
             )
 
+        # Selecting a subset of slices shrinks the z extent: the per-voxel
+        # thickness (affine z-column) is unchanged, but the field of view and
+        # the world origin must reflect the selected slab. The new grid is
+        # reindexed to start at 0, so shift the origin to the first selected
+        # slice's world position (assumes contiguous slices; for a sparse list
+        # slices[0] is used as the reference).
+        new_size = self.size.clone()
+        new_size[2] = self.size[2] * len(slices) / self.PD.shape[2]
+        new_affine = self.affine.clone()
+        new_affine[:3, 3] = self.affine[:3, 3] + self.affine[:3, 2] * slices[0]
+
         return VoxelGridPhantom(
             select(self.PD),
             select(self.T1),
@@ -349,8 +377,8 @@ class VoxelGridPhantom:
             select(self.B0),
             select_multicoil(self.B1),
             select_multicoil(self.coil_sens),
-            self.size.clone(),
-            self.affine.clone(),
+            new_size,
+            new_affine,
             tissue_masks={
                 key: mask[..., slices] for key, mask in self.tissue_masks.items()
             },
@@ -393,7 +421,7 @@ class VoxelGridPhantom:
             scale(self.B1.squeeze()).unsqueeze(0),
             scale(self.coil_sens.squeeze()).unsqueeze(0),
             self.size.clone(),
-            self.affine.clone(),
+            rescale_affine(self.affine, self.PD.shape, (x, y, z)),
             tissue_masks={
                 key: scale(mask) for key, mask in self.tissue_masks.items()
             }
@@ -476,7 +504,7 @@ class VoxelGridPhantom:
             resample_multicoil(self.B1),
             resample_multicoil(self.coil_sens),
             self.size.clone(),
-            self.affine.clone(),
+            rescale_affine(self.affine, self.PD.shape, (x, y, z)),
             tissue_masks=resample_masks(self.tissue_masks)
         )
 

--- a/python/MRzeroCore/phantom/voxel_grid_phantom.py
+++ b/python/MRzeroCore/phantom/voxel_grid_phantom.py
@@ -328,7 +328,7 @@ class VoxelGridPhantom:
         SimData
             A new instance containing the selected slice(s).
         """
-        assert 0 <= any([slices]) < self.PD.shape[2]
+        assert all(0 <= s < self.PD.shape[2] for s in slices)
 
         def select(tensor: torch.Tensor):
             return tensor[..., slices].view(
@@ -423,9 +423,26 @@ class VoxelGridPhantom:
         """
         def resample(tensor: torch.Tensor) -> torch.Tensor:
             # Introduce additional dimensions: mini-batch and channels
-            return torch.nn.functional.interpolate(
-                tensor[None, None, ...], size=(x, y, z), mode='trilinear'
+            src = tensor[None, None, ...]
+            finite = torch.isfinite(src)
+            if bool(finite.all()):
+                return torch.nn.functional.interpolate(
+                    src, size=(x, y, z), mode='trilinear'
+                )[0, 0, ...]
+            # Infinite entries (e.g. T2 == inf for "no relaxation") would create
+            # 0 * inf == NaN under the trilinear weights. Interpolate only the
+            # finite content, then re-stamp +/-inf wherever an infinite source
+            # voxel contributes with non-zero weight.
+            filled = torch.where(finite, src, torch.zeros_like(src))
+            out = torch.nn.functional.interpolate(
+                filled, size=(x, y, z), mode='trilinear'
             )[0, 0, ...]
+            for sign in (float("inf"), float("-inf")):
+                mass = torch.nn.functional.interpolate(
+                    (src == sign).to(src.dtype), size=(x, y, z), mode='trilinear'
+                )[0, 0, ...]
+                out = torch.where(mass > 0, torch.full_like(out, sign), out)
+            return out
 
         def resample_multicoil(tensor: torch.Tensor) -> torch.Tensor:
             coils = tensor.shape[0]


### PR DESCRIPTION
i dont know if this is planned, but this makes the legacy interpolate and slices compatible with the new affine standard.

two problems:  

1. interpolate created some Nans with the new affine reslice.  thsi si now caught
2. interpolate must alter the affine, otherwise the phantom size implicitly changes. which is also done here

I also updated the obj size when slices is used, this wasn't done yet also without affine, but should be done.


